### PR TITLE
Add MIC to publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -342,3 +342,4 @@ usedBy:
   - Automobile Club Oristano
   - Automobile Club Paova
   - Automobile Club Pavia
+  - Ministero della Cultura - MIC (m_bac)


### PR DESCRIPTION
Buongiorno @Devadip-Git , 

la seguente PR aggiunge il Ministero della Cultura - MIC alla lista di riutilizzatori come richiesto in #6.

Resto a disposizione, grazie